### PR TITLE
Rename again to reflect that this isn't just a logging library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/sporkmonger/ecslog
+    working_directory: /go/src/github.com/sporkmonger/ecsevent
     steps:
       - checkout
       - run: go get -v -t -d ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ECSLog
+# ECSEvent
 
 HTTP observability middleware using the Elastic Common Schema.
 
@@ -6,10 +6,10 @@ HTTP observability middleware using the Elastic Common Schema.
 
 ----
 
-ECSLog provides middleware and utility functions for logging in the ECS format,
+ECSEvent provides middleware and utility functions for logging in the ECS format,
 particularly for HTTP services.
 
-[GoDoc]: https://godoc.org/github.com/sporkmonger/ecslog
-[GoDoc Widget]: https://godoc.org/github.com/sporkmonger/ecslog?status.svg
-[Build]: https://circleci.com/gh/sporkmonger/ecslog
-[Build Widget]: https://circleci.com/gh/sporkmonger/ecslog.svg?style=shield
+[GoDoc]: https://godoc.org/github.com/sporkmonger/ecsevent
+[GoDoc Widget]: https://godoc.org/github.com/sporkmonger/ecsevent?status.svg
+[Build]: https://circleci.com/gh/sporkmonger/ecsevent
+[Build Widget]: https://circleci.com/gh/sporkmonger/ecsevent.svg?style=shield

--- a/ecs.go
+++ b/ecs.go
@@ -1,4 +1,4 @@
-package ecslog
+package ecsevent
 
 import (
 	"fmt"

--- a/ecs_test.go
+++ b/ecs_test.go
@@ -1,4 +1,4 @@
-package ecslog
+package ecsevent
 
 import (
 	"errors"

--- a/emit.go
+++ b/emit.go
@@ -1,6 +1,6 @@
-package ecslog
+package ecsevent
 
-// Emitter is a common interface for all ECSLog adapters.
+// Emitter is a common interface for all ECSEvent adapters.
 type Emitter interface {
 	// Emit takes a flat map of ECS fields and values, converts it to a nested
 	// map, and emits the event on the underlying logger implementation.

--- a/nesting.go
+++ b/nesting.go
@@ -1,4 +1,4 @@
-package ecslog
+package ecsevent
 
 import "strings"
 

--- a/nesting_test.go
+++ b/nesting_test.go
@@ -1,4 +1,4 @@
-package ecslog
+package ecsevent
 
 import (
 	"testing"

--- a/zerolog/emitter.go
+++ b/zerolog/emitter.go
@@ -2,7 +2,7 @@ package zerolog
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/sporkmonger/ecslog"
+	"github.com/sporkmonger/ecsevent"
 )
 
 // Emitter wraps a zerolog Logger allowing ECS formatted events to be emitted.
@@ -13,7 +13,7 @@ type Emitter struct {
 // Emit takes a flat map of ECS fields and values, converts it to a nested
 // map, and emits the event into the zerolog logger.
 func (e *Emitter) Emit(event map[string]interface{}) {
-	nested := ecslog.Nest(event)
+	nested := ecsevent.Nest(event)
 	e.Logger.Log().Fields(nested).Msg("")
 }
 
@@ -21,5 +21,5 @@ var (
 	// This is a compile-time check to make sure our types correctly
 	// implement the interface:
 	// https://medium.com/@matryer/c167afed3aae
-	_ ecslog.Emitter = &Emitter{}
+	_ ecsevent.Emitter = &Emitter{}
 )

--- a/zerolog/emitter_test.go
+++ b/zerolog/emitter_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sporkmonger/ecslog"
+	"github.com/sporkmonger/ecsevent"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -25,20 +25,20 @@ func TestEmitter(t *testing.T) {
 		{
 			"minimal event",
 			map[string]interface{}{
-				ecslog.FieldMessage: "hello world",
+				ecsevent.FieldMessage: "hello world",
 			},
 			`{"message":"hello world"}`,
 		},
 		{
 			"http event",
 			map[string]interface{}{
-				ecslog.FieldHTTPRequestMethod:      "GET",
-				ecslog.FieldHTTPRequestReferrer:    "http://example.com/",
-				ecslog.FieldHTTPResponseStatusCode: 200,
-				ecslog.FieldHTTPVersion:            "1.1",
-				ecslog.FieldSourceIP:               "127.0.0.1",
-				ecslog.FieldURLDomain:              "example.com",
-				ecslog.FieldURLFull:                "http://example.com/hello",
+				ecsevent.FieldHTTPRequestMethod:      "GET",
+				ecsevent.FieldHTTPRequestReferrer:    "http://example.com/",
+				ecsevent.FieldHTTPResponseStatusCode: 200,
+				ecsevent.FieldHTTPVersion:            "1.1",
+				ecsevent.FieldSourceIP:               "127.0.0.1",
+				ecsevent.FieldURLDomain:              "example.com",
+				ecsevent.FieldURLFull:                "http://example.com/hello",
 			},
 			`{"http":{"request":{"method":"GET","referrer":"http://example.com/"},"response":{"status_code":200},"version":"1.1"},"source":{"ip":"127.0.0.1"},"url":{"domain":"example.com","full":"http://example.com/hello"}}`,
 		},

--- a/zerolog/init.go
+++ b/zerolog/init.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/sporkmonger/ecslog"
+	"github.com/sporkmonger/ecsevent"
 )
 
 func init() {
@@ -13,10 +13,10 @@ func init() {
 }
 
 func zerologFieldInit() {
-	zerolog.LevelFieldName = ecslog.FieldLogLevel
-	zerolog.MessageFieldName = ecslog.FieldMessage
-	zerolog.ErrorFieldName = ecslog.FieldErrorMessage
-	zerolog.TimestampFieldName = ecslog.FieldTimestamp
+	zerolog.LevelFieldName = ecsevent.FieldLogLevel
+	zerolog.MessageFieldName = ecsevent.FieldMessage
+	zerolog.ErrorFieldName = ecsevent.FieldErrorMessage
+	zerolog.TimestampFieldName = ecsevent.FieldTimestamp
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	// Do not use caller for now.
 }

--- a/zerolog/init_test.go
+++ b/zerolog/init_test.go
@@ -6,15 +6,15 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sporkmonger/ecslog"
+	"github.com/sporkmonger/ecsevent"
 )
 
 func TestInit(t *testing.T) {
 	assert := assert.New(t)
 
 	zerologFieldInit()
-	assert.Equal(ecslog.FieldLogLevel, zerolog.LevelFieldName)
-	assert.Equal(ecslog.FieldMessage, zerolog.MessageFieldName)
-	assert.Equal(ecslog.FieldErrorMessage, zerolog.ErrorFieldName)
-	assert.Equal(ecslog.FieldTimestamp, zerolog.TimestampFieldName)
+	assert.Equal(ecsevent.FieldLogLevel, zerolog.LevelFieldName)
+	assert.Equal(ecsevent.FieldMessage, zerolog.MessageFieldName)
+	assert.Equal(ecsevent.FieldErrorMessage, zerolog.ErrorFieldName)
+	assert.Equal(ecsevent.FieldTimestamp, zerolog.TimestampFieldName)
 }


### PR DESCRIPTION
Since this library also manages open tracing in order to reduce code duplication between logged events in traces and logged events in normal logs, rename to ECSEvent. I also considered ECSEmit, which has the advantage of being 1 character shorter and being more "name-like", but "emit" doesn't really capture the fact that this is an abstraction over logs, traces, and metrics, whereas "event" gets a bit closer to that.