### PR TITLE
Add Root function to Monitor interface

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,8 +7,8 @@ import (
 // ctxKey is an unexported key for retrieving a logger from a context
 type ctxKey struct{}
 
-func (gm *RootMonitor) WithContext(ctx context.Context) context.Context {
-	return NewContext(ctx, gm)
+func (rm *RootMonitor) WithContext(ctx context.Context) context.Context {
+	return NewContext(ctx, rm)
 }
 
 func (sm *SpanMonitor) WithContext(ctx context.Context) context.Context {

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -20,8 +20,8 @@ func (me *mockEmitter) Events() []map[string]interface{} {
 }
 
 func EmitToMock(mock *mockEmitter) MonitorOption {
-	return func(gm *RootMonitor) {
-		gm.AppendEmitter(mock)
+	return func(rm *RootMonitor) {
+		rm.AppendEmitter(mock)
 	}
 }
 

--- a/nop.go
+++ b/nop.go
@@ -33,3 +33,8 @@ func (nm *NopMonitor) UpdateFields(event map[string]interface{}) {}
 func Nop() *NopMonitor {
 	return &NopMonitor{}
 }
+
+// Root returns nil.
+func (nm *NopMonitor) Root() *RootMonitor {
+	return nil
+}


### PR DESCRIPTION
There's a lot of type assertions that have to happen for the common task of interacting with the `RootMonitor`. This eliminates that problem at the cost of possibly introducing `nil` panics with `NopMonitor`. However `SpanMonitor` could already return `nil`.