### PR TITLE
Use the tracer associated with the RootMonitor

### DIFF
--- a/httpmw/middleware.go
+++ b/httpmw/middleware.go
@@ -98,14 +98,16 @@ func NewHandler(monitor ecsevent.Monitor) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			timeStart := time.Now()
 
+			tracer := monitor.Root().Tracer()
+
 			var opentracingSpan opentracing.Span
-			wireContext, _ := opentracing.GlobalTracer().Extract(
+			wireContext, _ := tracer.Extract(
 				opentracing.HTTPHeaders,
 				opentracing.HTTPHeadersCarrier(r.Header))
 
 			// Create the span referring to the RPC client if available.
 			// If wireContext == nil, a root span will be created.
-			opentracingSpan = opentracing.StartSpan(
+			opentracingSpan = tracer.StartSpan(
 				fmt.Sprintf("%s %s", r.Method, r.Host),
 				ext.RPCServerOption(wireContext))
 

--- a/httpmw/middleware_test.go
+++ b/httpmw/middleware_test.go
@@ -209,7 +209,7 @@ func TestOpenTracing(t *testing.T) {
 	time.Sleep(1 * time.Nanosecond)
 
 	mock := &mockEmitter{events: make([]map[string]interface{}, 0)}
-	monitor := ecsevent.New(EmitToMock(mock), ecsevent.NestEvents(true))
+	monitor := ecsevent.New(EmitToMock(mock), ecsevent.NestEvents(true), ecsevent.Tracer(tracer))
 	mh := NewHandler(monitor.(*ecsevent.RootMonitor))
 
 	req, err := http.NewRequest("GET", "/health-check", nil)
@@ -281,7 +281,7 @@ func TestOpenTracingWithJaeger(t *testing.T) {
 	defer closer.Close()
 
 	mock := &mockEmitter{events: make([]map[string]interface{}, 0)}
-	monitor := ecsevent.New(EmitToMock(mock), ecsevent.NestEvents(true))
+	monitor := ecsevent.New(EmitToMock(mock), ecsevent.NestEvents(true), ecsevent.Tracer(tracer))
 	mh := NewHandler(monitor.(*ecsevent.RootMonitor))
 
 	req, err := http.NewRequest("GET", "/health-check", nil)

--- a/monitor.go
+++ b/monitor.go
@@ -69,6 +69,13 @@ func Stackdriver(stackdriver bool) MonitorOption {
 	}
 }
 
+// Tracer associates a Monitor with an opentracing tracer.
+func Tracer(tracer opentracing.Tracer) MonitorOption {
+	return func(rm *RootMonitor) {
+		rm.SetTracer(tracer)
+	}
+}
+
 // New creates a new RootMonitor with the given MonitorOption functions
 // applied.
 func New(opts ...MonitorOption) Monitor {
@@ -115,6 +122,14 @@ func (rm *RootMonitor) SetTracer(tracer opentracing.Tracer) {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 	rm.tracer = tracer
+}
+
+// Tracer returns the tracer for the RootMonitor. Unlike emitters, there
+// can be only one tracer.
+func (rm *RootMonitor) Tracer() opentracing.Tracer {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	return rm.tracer
 }
 
 // SetStackdriverLogging enables or disables translation of ECS events into


### PR DESCRIPTION
Rather than using the opentracing global tracer, use the root tracer.